### PR TITLE
Convert super calls to python 2 style

### DIFF
--- a/antispam/captcha/forms.py
+++ b/antispam/captcha/forms.py
@@ -44,7 +44,7 @@ class ReCAPTCHA(forms.Field):
         elif isinstance(kwargs['widget'], type):
             kwargs['widget'] = kwargs['widget'](sitekey=self.sitekey)
 
-        super().__init__(**kwargs)
+        super(ReCAPTCHA, self).__init__(**kwargs)
 
     def validate(self, value):
         """
@@ -53,7 +53,7 @@ class ReCAPTCHA(forms.Field):
         :raise ValidationError with code="captcha-error" if reCAPTCHA service is unavailable or working incorrectly.
         :raise ValidationError with code="captcha-invalid" if reCAPTCHA validation failed.
         """
-        super().validate(value)
+        super(ReCAPTCHA, self).validate(value)
 
         try:
             resp = requests.post('https://www.google.com/recaptcha/api/siteverify', {

--- a/antispam/captcha/widgets.py
+++ b/antispam/captcha/widgets.py
@@ -12,7 +12,7 @@ class ReCAPTCHA(forms.Widget):
         """
         :param sitekey: site key (public key) 
         """
-        super().__init__()
+        super(ReCAPTCHA, self).__init__()
 
         self.sitekey = sitekey
 

--- a/antispam/honeypot/forms.py
+++ b/antispam/honeypot/forms.py
@@ -21,7 +21,7 @@ class HoneypotField(forms.CharField):
         kwargs.setdefault('max_length', 255)
         kwargs.setdefault('widget', HoneypotInput)
 
-        super().__init__(**kwargs)
+        super(HoneypotField, self).__init__(**kwargs)
 
     def validate(self, value):
         """
@@ -30,7 +30,7 @@ class HoneypotField(forms.CharField):
         :param value: user-input
         :raise: ValidationError with code="spam-protection" if honeypot check failed.
         """
-        super().validate(value)
+        super(HoneypotField, self).validate(value)
 
         if value:
             raise ValidationError(self.error_messages['honeypot'], code='spam-protection')

--- a/antispam/honeypot/widgets.py
+++ b/antispam/honeypot/widgets.py
@@ -17,5 +17,5 @@ class HoneypotInput(forms.TextInput):
         Returns this widget rendered as HTML.
         """
         return mark_safe(
-            '<div style="display: none;">%s</div>' % str(super().render(*args, **kwargs))
+            '<div style="display: none;">%s</div>' % str(super(HoneypotInput, self).render(*args, **kwargs))
         )


### PR DESCRIPTION
I tried using this library in a legacy python 2 environment and it turned out that all I needed to do to get it working was convert the super calls back to the old style.  