### PR TITLE
Renames imports for Django 4.1 compatibility.

### DIFF
--- a/antispam/captcha/forms.py
+++ b/antispam/captcha/forms.py
@@ -3,7 +3,7 @@ from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import default_settings
 

--- a/antispam/honeypot/forms.py
+++ b/antispam/honeypot/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .widgets import HoneypotInput
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.3
+current_version = 1.0.4
 commit = True
 tag = True
 files = setup.py

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-antispam',
-    version='1.0.3',
+    version='1.0.4',
     url='https://github.com/mixkorshun/django-antispam',
     description='Anti-spam protection tools for django applications.',
     keywords=['anti-spam', 'antispam', 'spam'],


### PR DESCRIPTION
Only renames imported functions for Django 4.1 compatibility.

These `ugettext => gettext` naming changes were marked as deprecated in Django 3.0:

https://docs.djangoproject.com/en/3.0/releases/3.0/#features-deprecated-in-3-0

Thank you!