### PR TITLE
Replaced ugettext_lazy with gettext_lazy for Django 3+ compatibility.

### DIFF
--- a/antispam/captcha/forms.py
+++ b/antispam/captcha/forms.py
@@ -3,7 +3,7 @@ from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import default_settings
 

--- a/antispam/honeypot/forms.py
+++ b/antispam/honeypot/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .widgets import HoneypotInput
 


### PR DESCRIPTION
Since `ugettext_lazy` has been deprecated since Django 3.0, I've replaced honeypot and recaptcha forms.py imports with `gettext_lazy` for Django 3+ compatibility.